### PR TITLE
중복으로 firebase child 생성되는 문제 수정

### DIFF
--- a/app/src/main/java/com/cookandroid/s2_archiving/ResisterActivity.kt
+++ b/app/src/main/java/com/cookandroid/s2_archiving/ResisterActivity.kt
@@ -41,7 +41,6 @@ class ResisterActivity : AppCompatActivity() {
         //이메일 중복 확인 버튼
 
         mBtnConfirmID.setOnClickListener {
-            mDatabaseRef = FirebaseDatabase.getInstance().getReference("Firebase").child("Firebase")
             mDatabaseRef.orderByChild("userEmail").equalTo("${mEtEmail.text.toString()}")
                     .addListenerForSingleValueEvent(object : ValueEventListener {
                         override fun onCancelled(error: DatabaseError) {
@@ -90,8 +89,8 @@ class ResisterActivity : AppCompatActivity() {
                             //account.userPhone = strPhone
                             account.userPwd = strPwd
 
-                            // setValue : database에 insert (삽입) 행위위
-                            mDatabaseRef.child("Firebase").child(firebaseUser?.uid.toString())
+                            // setValue : database에 insert (삽입) 행위
+                            mDatabaseRef.child(firebaseUser?.uid.toString())
                                 .setValue(account)
 
                             Toast.makeText(this, "회원가입에 성공하셨습니다", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
해야할 일
- firebase -> UserAccount로 이름 바꿔야 할 것 같음
- 이메일 중복확인
- 정보 수정시에 이메일은 변경 불가능
- realtime database에서는 변경이 잘 되지만 실제 authentication에서는 비밀번호 update가 안되는지 로그인안됨
